### PR TITLE
Adding more test coverage and support for GAE OAuth

### DIFF
--- a/gaeauth/backends.py
+++ b/gaeauth/backends.py
@@ -23,12 +23,13 @@ class GoogleAccountBackend(ModelBackend):
         if g_user == None:
             return None
 
-        username = self.clean_username(g_user.email())
+        username, domain = g_user.email().split('@')
 
-        if hasattr(settings, 'ALLOWED_USERS'):
-            try:
-                settings.ALLOWED_USERS.index(username)
-            except ValueError:
+        # Check for settings whitelists.
+        for setting, value in (('ALLOWED_USERS', username),
+                               ('ALLOWED_DOMAINS', domain)):
+            if (hasattr(settings, setting) and
+                value not in getattr(settings, setting)):
                 return None
 
         user, created = User.objects.get_or_create(

--- a/gaeauth/middleware.py
+++ b/gaeauth/middleware.py
@@ -1,5 +1,33 @@
+from google.appengine.api import users
+from django.contrib import auth
 from django.contrib.auth.middleware import RemoteUserMiddleware
 
 
 class GoogleRemoteUserMiddleware(RemoteUserMiddleware):
-    header = 'USER_EMAIL'
+    def get_current_user(self):
+        return users.get_current_user()
+
+    def is_current_user_admin(self):
+        return users.is_current_user_admin()
+
+    def process_request(self, request):
+        user = self.get_current_user()
+        if not user:
+            # leave request.user set to AnonymousUser by the
+            # AuthenticationMiddleware.
+            return
+        # If the user is already authenticated and that user is the user we get
+        # back from get_current_user(), then the correct user is already
+        # persisted in the session and we don't need to continue.
+        if request.user.is_authenticated():
+            if request.user.username == self.clean_username(user, request):
+                return
+        # We are seeing this user for the first time in this session, attempt
+        # to authenticate the user.
+        user = auth.authenticate(user=user,
+                                 admin=self.is_current_user_admin())
+        if user:
+            # User is valid.  Set request.user and persist user in the session
+            # by logging the user in.
+            request.user = user
+            auth.login(request, user)

--- a/gaeauth/tests/__init__.py
+++ b/gaeauth/tests/__init__.py
@@ -1,0 +1,2 @@
+from gaeauth.tests.backends import *
+from gaeauth.tests.models import *

--- a/gaeauth/tests/__init__.py
+++ b/gaeauth/tests/__init__.py
@@ -1,2 +1,4 @@
 from gaeauth.tests.backends import *
+from gaeauth.tests.middleware import *
 from gaeauth.tests.models import *
+from gaeauth.tests.views import *

--- a/gaeauth/tests/backends.py
+++ b/gaeauth/tests/backends.py
@@ -34,6 +34,14 @@ class GoogleAccountBackendTest(TestCase):
         self.assertEqual('bar', auth.authenticate().username)
         del settings.ALLOWED_USERS
 
+    def test_allowed_domains(self):
+        """Tests when user has supplied an ALLOWED_DOMAINS settings entry."""
+        settings.ALLOWED_DOMAINS = ('fail.example.com',)
+        self.assertIsNone(auth.authenticate())
+        settings.ALLOWED_DOMAINS = ('example.com',)
+        self.assertEqual('foo', auth.authenticate().username)
+        del settings.ALLOWED_DOMAINS
+
     def test_configure_user(self):
         """Tests that App Engine admin User object gets staff/superuser."""
         users.should_receive('is_current_user_admin').and_return(True)

--- a/gaeauth/tests/backends.py
+++ b/gaeauth/tests/backends.py
@@ -7,16 +7,6 @@ from gaeauth.backends import GoogleAccountBackend
 from google.appengine.api import users
 
 
-class ModelsTest(TestCase):
-    def test_password_indexed(self):
-        """Tests that the password field on the User model is indexed."""
-        password_indexed = False
-        for field in User._meta.local_fields:
-            if field.column == 'password':
-                password_indexed = field.db_index
-        self.assertTrue(password_indexed)
-
-
 class GoogleAccountBackendTest(TestCase):
     def setUp(self):
         settings.AUTHENTICATION_BACKENDS = (

--- a/gaeauth/tests/middleware.py
+++ b/gaeauth/tests/middleware.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
 from flexmock import flexmock
+from google.appengine.api import oauth
 from google.appengine.api import users
 
 
@@ -9,6 +10,7 @@ class GoogleRemoteUserMiddlewareTest(TestCase):
     urls = 'gaeauth.tests.urls'
     middleware = 'gaeauth.middleware.GoogleRemoteUserMiddleware'
     backend = 'gaeauth.backends.GoogleAccountBackend'
+    users_api = users
 
     def setUp(self):
         self.curr_middleware = settings.MIDDLEWARE_CLASSES
@@ -16,9 +18,10 @@ class GoogleRemoteUserMiddlewareTest(TestCase):
         settings.MIDDLEWARE_CLASSES += (self.middleware,)
         settings.AUTHENTICATION_BACKENDS = (self.backend,)
         self.email = 'user@example.com'
-        flexmock(users)
-        users.should_receive('get_current_user').and_return(users.User(
+        flexmock(self.users_api)
+        self.users_api.should_receive('get_current_user').and_return(users.User(
             email=self.email, _auth_domain='example.com', _user_id=12345))
+        self.users_api.should_receive('is_current_user_admin').and_return(False)
 
     def tearDown(self):
         settings.MIDDLEWARE_CLASSES = self.curr_middleware
@@ -30,7 +33,7 @@ class GoogleRemoteUserMiddlewareTest(TestCase):
         the App Engine users API.
         """
         num_users = User.objects.count()
-        users.should_receive('get_current_user').and_return(None)
+        self.users_api.should_receive('get_current_user').and_return(None)
         response = self.client.get('/remote_user/')
         self.assertTrue(response.context['user'].is_anonymous())
         self.assertEqual(User.objects.count(), num_users)
@@ -41,7 +44,7 @@ class GoogleRemoteUserMiddlewareTest(TestCase):
         API does not yet exist as a Django User.
         """
         num_users = User.objects.count()
-        response = self.client.get('/remote_user/', USER_EMAIL=self.email)
+        response = self.client.get('/remote_user/')
         self.assertEqual(response.context['user'].username, 'user')
         self.assertEqual(User.objects.count(), num_users + 1)
         User.objects.get(username='user')
@@ -52,16 +55,31 @@ class GoogleRemoteUserMiddlewareTest(TestCase):
         """
         User.objects.create(username='user', password='12345')
         num_users = User.objects.count()
-        response = self.client.get('/remote_user/', USER_EMAIL=self.email)
+        response = self.client.get('/remote_user/')
         self.assertEqual(response.context['user'].username, 'user')
         self.assertEqual(User.objects.count(), num_users)
         # Test that a different user passed in the headers causes the new user
         # to be created.
         email2 = 'user2@example.com'
-        users.should_receive('get_current_user').and_return(users.User(
+        self.users_api.should_receive('get_current_user').and_return(users.User(
             email=email2, _auth_domain='example.com', _user_id=123456))
-        response = self.client.get('/remote_user/', USER_EMAIL=email2)
+        response = self.client.get('/remote_user/')
         self.assertEqual(response.context['user'].username, 'user2')
         self.assertEqual(User.objects.count(), num_users + 1)
 
 
+class GoogleOAuthRemoteUserMiddlewareTest(GoogleRemoteUserMiddlewareTest):
+    middleware = 'gaeauth.middleware.GoogleOAuthRemoteUserMiddleware'
+    users_api = oauth
+
+    def test_no_google_user(self):
+        """
+        Tests that no user is created when there is an exception raised by the
+        App Engine OAuth users API.
+        """
+        num_users = User.objects.count()
+        self.users_api.should_receive('get_current_user').and_raise(
+            oauth.OAuthRequestError)
+        response = self.client.get('/remote_user/')
+        self.assertTrue(response.context['user'].is_anonymous())
+        self.assertEqual(User.objects.count(), num_users)

--- a/gaeauth/tests/middleware.py
+++ b/gaeauth/tests/middleware.py
@@ -30,6 +30,7 @@ class GoogleRemoteUserMiddlewareTest(TestCase):
         the App Engine users API.
         """
         num_users = User.objects.count()
+        users.should_receive('get_current_user').and_return(None)
         response = self.client.get('/remote_user/')
         self.assertTrue(response.context['user'].is_anonymous())
         self.assertEqual(User.objects.count(), num_users)

--- a/gaeauth/tests/middleware.py
+++ b/gaeauth/tests/middleware.py
@@ -1,0 +1,66 @@
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import TestCase
+from flexmock import flexmock
+from google.appengine.api import users
+
+
+class GoogleRemoteUserMiddlewareTest(TestCase):
+    urls = 'gaeauth.tests.urls'
+    middleware = 'gaeauth.middleware.GoogleRemoteUserMiddleware'
+    backend = 'gaeauth.backends.GoogleAccountBackend'
+
+    def setUp(self):
+        self.curr_middleware = settings.MIDDLEWARE_CLASSES
+        self.curr_auth = settings.AUTHENTICATION_BACKENDS
+        settings.MIDDLEWARE_CLASSES += (self.middleware,)
+        settings.AUTHENTICATION_BACKENDS = (self.backend,)
+        self.email = 'user@example.com'
+        flexmock(users)
+        users.should_receive('get_current_user').and_return(users.User(
+            email=self.email, _auth_domain='example.com', _user_id=12345))
+
+    def tearDown(self):
+        settings.MIDDLEWARE_CLASSES = self.curr_middleware
+        settings.AUTHENTICATION_BACKENDS = self.curr_auth
+
+    def test_no_google_user(self):
+        """
+        Tests that no user is created when there is no Google user returned by
+        the App Engine users API.
+        """
+        num_users = User.objects.count()
+        response = self.client.get('/remote_user/')
+        self.assertTrue(response.context['user'].is_anonymous())
+        self.assertEqual(User.objects.count(), num_users)
+
+    def test_unknown_user(self):
+        """
+        Tests the case where the Google user returned by the App Engine users
+        API does not yet exist as a Django User.
+        """
+        num_users = User.objects.count()
+        response = self.client.get('/remote_user/', USER_EMAIL=self.email)
+        self.assertEqual(response.context['user'].username, 'user')
+        self.assertEqual(User.objects.count(), num_users + 1)
+        User.objects.get(username='user')
+
+    def test_known_user(self):
+        """
+        Tests the case where the Google user already exists as a Django user.
+        """
+        User.objects.create(username='user', password='12345')
+        num_users = User.objects.count()
+        response = self.client.get('/remote_user/', USER_EMAIL=self.email)
+        self.assertEqual(response.context['user'].username, 'user')
+        self.assertEqual(User.objects.count(), num_users)
+        # Test that a different user passed in the headers causes the new user
+        # to be created.
+        email2 = 'user2@example.com'
+        users.should_receive('get_current_user').and_return(users.User(
+            email=email2, _auth_domain='example.com', _user_id=123456))
+        response = self.client.get('/remote_user/', USER_EMAIL=email2)
+        self.assertEqual(response.context['user'].username, 'user2')
+        self.assertEqual(User.objects.count(), num_users + 1)
+
+

--- a/gaeauth/tests/models.py
+++ b/gaeauth/tests/models.py
@@ -1,0 +1,11 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+class ModelsTest(TestCase):
+    def test_password_indexed(self):
+        """Tests that the password field on the User model is indexed."""
+        password_indexed = False
+        for field in User._meta.local_fields:
+            if field.column == 'password':
+                password_indexed = field.db_index
+        self.assertTrue(password_indexed)

--- a/gaeauth/tests/urls.py
+++ b/gaeauth/tests/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls.defaults import *
+from django.contrib.auth.tests import urls as auth_urls
+from gaeauth import urls as gaeauth_urls
+
+urlpatterns = auth_urls.urlpatterns + patterns('',
+    url('^gaeauth/', include(gaeauth_urls)),
+)

--- a/gaeauth/tests/views.py
+++ b/gaeauth/tests/views.py
@@ -18,9 +18,9 @@ class GaeauthViewsTest(TestCase):
         settings.AUTHENTICATION_BACKENDS = (
             'gaeauth.backends.GoogleAccountBackend',
         )
-        flexmock(users).should_receive('get_current_user').and_return(
-            users.User(email='foo@example.com', _auth_domain='example.com',
-                       _user_id=12345))
+        self.user = users.User(
+            email='foo@example.com', _auth_domain='example.com', _user_id=12345)
+        flexmock(users).should_receive('get_current_user').and_return(self.user)
 
     def tearDown(self):
         self.testbed.deactivate()
@@ -44,7 +44,7 @@ class GaeauthViewsTest(TestCase):
                      response['Location'])
 
     def test_logout(self):
-        self.client.login()
+        self.client.login(user=self.user)
         self.assert_(SESSION_KEY in self.client.session)
         response = self.client.get('/gaeauth/logout/')
         self.assertEqual(response.status_code, 302)

--- a/gaeauth/tests/views.py
+++ b/gaeauth/tests/views.py
@@ -1,0 +1,64 @@
+import urllib
+
+from django.conf import settings
+from django.contrib.auth import SESSION_KEY
+from django.test import TestCase
+from google.appengine.api import users
+from google.appengine.ext import testbed
+from flexmock import flexmock
+
+
+class GaeauthViewsTest(TestCase):
+    urls = 'gaeauth.tests.urls'
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_user_stub()
+        settings.AUTHENTICATION_BACKENDS = (
+            'gaeauth.backends.GoogleAccountBackend',
+        )
+        flexmock(users).should_receive('get_current_user').and_return(
+            users.User(email='foo@example.com', _auth_domain='example.com',
+                       _user_id=12345))
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def test_login_with_invalid_next_param(self):
+        response = self.client.get('/gaeauth/login/')
+        self.assertEqual(response.status_code, 302)
+        self.assert_(urllib.quote('/gaeauth/authenticate/?next=/') in
+                     response['Location'])
+        response = self.client.get('/gaeauth/login/', {'next': 'http://host'})
+        self.assert_(urllib.quote('/gaeauth/authenticate/?next=/') in
+                     response['Location'])
+        response = self.client.get('/gaeauth/login/', {'next': '/space path'})
+        self.assert_(urllib.quote('/gaeauth/authenticate/?next=/') in
+                     response['Location'])
+
+    def test_login_with_valid_next_param(self):
+        response = self.client.get('/gaeauth/login/', {'next': '/foo'})
+        self.assertEqual(response.status_code, 302)
+        self.assert_(urllib.quote('/gaeauth/authenticate/?next=/foo') in
+                     response['Location'])
+
+    def test_logout(self):
+        self.client.login()
+        self.assert_(SESSION_KEY in self.client.session)
+        response = self.client.get('/gaeauth/logout/')
+        self.assertEqual(response.status_code, 302)
+        self.assert_(SESSION_KEY not in self.client.session)
+
+    def test_authenticate(self):
+        self.assert_(SESSION_KEY not in self.client.session)
+        response = self.client.get('/gaeauth/authenticate/', {'next': '/foo'})
+        self.assert_(SESSION_KEY in self.client.session)
+        self.assertEqual(response.status_code, 302)
+        self.assert_('/foo' in response['Location'])
+
+    def test_authenticate_when_django_auth_fails(self):
+        users.should_receive('get_current_user').and_return(None)
+        response = self.client.get('/gaeauth/authenticate/', {'next': '/foo'})
+        self.assertEqual(response.status_code, 302)
+        self.assert_('/invalid' in response['Location'])

--- a/gaeauth/views.py
+++ b/gaeauth/views.py
@@ -24,7 +24,8 @@ def logout(request):
 
 
 def authenticate(request):
-    user = django_authenticate()
+    user = django_authenticate(
+        user=users.get_current_user(), admin=users.is_current_user_admin())
     if user is not None:
         django_login(request, user)
         #redirect to valid logged page (preferably the user's request)

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import sys
+
+from django.conf import settings
+from django.core import management
+
+
+def runtests(args):
+  settings.configure(
+      DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3'}},
+      INSTALLED_APPS=(
+          'django.contrib.auth',
+          'django.contrib.contenttypes',
+          'django.contrib.sessions',
+          'gaeauth',
+      ),
+      ROOT_URLCONF='urls')
+  management.call_command('test', *args)
+
+
+if __name__ == '__main__':
+  runtests(sys.argv[1:])


### PR DESCRIPTION
Hey Florian,

I got busy with making some improvements on the django-gaeauth app in a Git fork, and I'd like you to check out my changes and pull them to the main repo.  The main addition which prompted the changes was to add support for authenticating users via the App Engine OAuth api (google.appengine.api.oauth) in addition to the traditional users API.

Before adding the functionality, I took the time to write tests for all the previous untested code, so that I could be sure I didn't foul anything up during the refactoring.  There's quite a bit of code movement, but the tests should pass at each commit, and hopefully indicates that everything should be fine.

Let me know what you think!
