### PR TITLE
Fixed a bug where we're improperly inserting an int in os.environ

### DIFF
--- a/gaeauth/tests/gae.py
+++ b/gaeauth/tests/gae.py
@@ -35,4 +35,4 @@ class GaeOauthUserApiTestMixin(GaeUserApiTestMixin):
 
     def logout_user(self):
         error_code = user_service_pb.UserServiceError.OAUTH_INVALID_REQUEST
-        self.testbed.setup_env(oauth_error_code=error_code, overwrite=True)
+        self.testbed.setup_env(oauth_error_code=str(error_code), overwrite=True)


### PR DESCRIPTION
The dev_appserver testbed currently does some monkey patching and replaces os.environ with a dictionary so this doesn't currently cause an issue.  However, if that changes, our test will fail if it executes against the real os.environ object.

```
>>> os.environ['foo'] = 1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.6/os.py", line 471, in __setitem__
    putenv(key, item)
TypeError: putenv() argument 2 must be string, not int
```
