### PR TITLE
Fix tests to pass with recent GAE SDK versions

### DIFF
--- a/gaeauth/tests/gae.py
+++ b/gaeauth/tests/gae.py
@@ -32,7 +32,10 @@ class GaeOauthUserApiTestMixin(GaeUserApiTestMixin):
                                overwrite=True)
         self.testbed.setup_env(oauth_is_admin='1' if is_admin else '0',
                                overwrite=True)
+        self.testbed.setup_env(oauth_last_scope='', overwrite=True)
 
     def logout_user(self):
         error_code = user_service_pb.UserServiceError.OAUTH_INVALID_REQUEST
         self.testbed.setup_env(oauth_error_code=str(error_code), overwrite=True)
+        self.testbed.setup_env(oauth_error_detail='Error', overwrite=True)
+        self.testbed.setup_env(oauth_last_scope='', overwrite=True)


### PR DESCRIPTION
This fixes tests which are currently failing at HEAD when running against GAE SDK v1.9.11.

```
======================================================================
FAIL: test_known_user (gaeauth.tests.middleware.GoogleOAuthRemoteUserMiddlewareTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/mmcdonald/src/django-gaeauth/gaeauth/tests/middleware.py", line 61, in test_known_user
    self.assertEqual(response.context['user'].username, 'user')
AssertionError: 'example' != 'user'

======================================================================
FAIL: test_no_google_user (gaeauth.tests.middleware.GoogleOAuthRemoteUserMiddlewareTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/mmcdonald/src/django-gaeauth/gaeauth/tests/middleware.py", line 85, in test_no_google_user
    self.assertTrue(response.context['user'].is_anonymous())
AssertionError: False is not true

======================================================================
FAIL: test_unknown_user (gaeauth.tests.middleware.GoogleOAuthRemoteUserMiddlewareTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/mmcdonald/src/django-gaeauth/gaeauth/tests/middleware.py", line 46, in test_unknown_user
    self.assertEqual(response.context['user'].username, 'user')
AssertionError: 'example' != 'user'

----------------------------------------------------------------------
Ran 19 tests in 0.129s

FAILED (failures=3)
Destroying test database for alias 'default'...
```
